### PR TITLE
improve setup script

### DIFF
--- a/.env
+++ b/.env
@@ -1,6 +1,6 @@
 ANALYTICS_ENABLED=false
 ANALYTICS_NAME=rbb-data-{project-name}
-ANALYTICS_TITLE={Project Name}
+ANALYTICS_TITLE={project-name}
 ANALYTICS_HANDLE=https://rbb24.de/static/rbb/rbb-data/{project-name}
 ANALYTICS_CREATE_DATE={JJJJMMDD}
 URL_PREFIX={project-name}

--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ Propably you also want to add a remote.
 For example:
 
 ```
-git remote add origin https://docs.rbb-online.de/bitbucket/scm/rdat/coll-project-name.git
+git remote add origin https://docs.rbb-online.de/bitbucket/scm/rdat/cool-project-name.git
 git push -u origin main
 ```
 

--- a/README.md
+++ b/README.md
@@ -4,18 +4,15 @@ This project was bootstrapped with the [rbb starter](https://github.com/rbb-data
 
 ## Start a new Project:
 
-To create a new project just run:
+To create a new project, pick a `cool-project-name` and run:
 
 ```bash
-git clone git@github.com:rbb-data/starter.git my-rbb-data-project --depth 1
-cd my-rbb-data-project
-rm -rf .git
-git init
-git add --all
-git commit -m "Init with clone from rbb-data starter"
+git clone git@github.com:rbb-data/starter.git cool-project-name --depth 1
+cd cool-project-name
+npm install
 ```
 
-Replace "my-rbb-data-project" with the name of your project.
+Note that `cool-project-name` will be used in various places and will by default also determine the path on the server where the app will be available.
 
 Propably you also want to add a remote.
 For example:

--- a/README.md
+++ b/README.md
@@ -18,11 +18,9 @@ Propably you also want to add a remote.
 For example:
 
 ```
-git remote add origin https://docs.rbb-online.de/bitbucket/scm/rdat/my-rbb-data-project.git
-git push -u origin master
+git remote add origin https://docs.rbb-online.de/bitbucket/scm/rdat/coll-project-name.git
+git push -u origin main
 ```
-
-Adjust the project name/path in the following files: `.env` and `package.json` (see below).
 
 ## Folder structure
 

--- a/package.json
+++ b/package.json
@@ -3,6 +3,7 @@
   "version": "0.1.0",
   "private": true,
   "scripts": {
+    "prepare": "scripts/setup.sh",
     "dev": "next",
     "start": "next start",
     "build": "next build",

--- a/scripts/setup.sh
+++ b/scripts/setup.sh
@@ -14,7 +14,7 @@ git log --oneline | grep -q 'Start new project with https://github.com/rbb-data/
 cd $(dirname $0)/..
 
 # substitute '{project-name}' with the current folder name
-sed -i 's/{project-name}/'"$(basename $(pwd))"'/g' .env package.json
+sed -i '' 's/{project-name}/'"$(basename $(pwd))"'/g' .env package.json
 
 # clean up the git history
 git commit --amend -m 'Start new project with https://github.com/rbb-data/starter/tree/'$(git rev-parse --short HEAD)

--- a/scripts/setup.sh
+++ b/scripts/setup.sh
@@ -1,6 +1,15 @@
 #!/usr/bin/env bash
 
-# this script is meant to run once after having cloned the repository
+# this script is meant to run once after having cloned the repository.
+# because it is setup in `.scripts.prepare` in `package.json`, it will
+# automatically run when doing an `npm install`.
+
+# print every executed line and abort when one fails
+set -ex
+
+# avoid running the setup script multiple times
+git log --oneline | grep -q 'Start new project with https://github.com/rbb-data/starter' && exit 0
+
 # make sure to run from project root
 cd $(dirname $0)/..
 

--- a/scripts/setup.sh
+++ b/scripts/setup.sh
@@ -1,0 +1,12 @@
+#!/usr/bin/env bash
+
+# this script is meant to run once after having cloned the repository
+# make sure to run from project root
+cd $(dirname $0)/..
+
+# substitute '{project-name}' with the current folder name
+sed -i 's/{project-name}/'"$(basename $(pwd))"'/g' .env package.json
+
+# clean up the git history
+git commit --amend -m 'Start new project with https://github.com/rbb-data/starter/tree/'$(git rev-parse --short HEAD)
+git remote remove origin

--- a/scripts/setup.sh
+++ b/scripts/setup.sh
@@ -7,6 +7,9 @@
 # print every executed line and abort when one fails
 set -ex
 
+# skip when deploying to vercel (see https://vercel.com/docs/environment-variables#system-environment-variables)
+[ -z "$CI" ] || exit 0
+
 # avoid running the setup script multiple times
 git log --oneline | grep -q 'Start new project with https://github.com/rbb-data/starter' && exit 0
 


### PR DESCRIPTION
This improves setting up a new project somewhat

1. `{project-name}` is now simply the name you choose for the folder you clone the starter into
2. The `{project-name}` is automatically filled in everywhere it's needed once you run `npm install`
3. The git initial commit now contains a link to the `HEAD` of the starter repo at the point of cloning. This might make later bugfixes easier to reconcile.