### PR TITLE
Add iframe resizer script by default

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,6 +39,12 @@ This App can track "pageviews" and e.g. map interactions.
 To enable this you need to replace everything in `{}` in the ANALYTICS variables in the `.env` file
 and set `ANALYTICS_ENABLED` to true.
 
+## Embed as iFrame
+
+`iframe-embed.html` contains code to embed your app into another page. It supports [David J. Bradshaw's iFrame Resizer script](https://github.com/davidjbradshaw/iframe-resizer) by default.
+
+Note that the iFrame should be given an appropriate title.
+
 ## Deveolpment and build Scripts
 
 In the project directory, you can run:

--- a/iframe-embed.html
+++ b/iframe-embed.html
@@ -1,5 +1,6 @@
 <iframe title="{ein Bildtitel o.ä.}" loading="lazy" width="100%" height="600" id="rbb-data--{project-name}" src="https://www.rbb-online.de/static/rbb/rbb-data/{project-name}/"></iframe>
 <style>
+  /* explained here: https://github.com/davidjbradshaw/iframe-resizer#typical-setup */
   #rbb-data--{project-name} {
     width: 1px;
     min-width: 100%;

--- a/iframe-embed.html
+++ b/iframe-embed.html
@@ -1,0 +1,16 @@
+<iframe title="{ein Bildtitel o.ä.}" loading="lazy" width="100%" height="600" id="rbb-data--{project-name}" src="https://www.rbb-online.de/static/rbb/rbb-data/{project-name}/"></iframe>
+<style>
+  #rbb-data--{project-name} {
+    width: 1px;
+    min-width: 100%;
+  }
+  /* fix position in app */
+  @media screen and (max-width: 630px) {
+    #rbb-data--{project-name} {
+      width: 100%; /* full width in app */
+      margin-left: 0; /* center in app */
+    }
+  }
+</style>
+<script src="https://www.rbb-online.de/static/rbb/rbb-data/{project-name}/iframeResizer.min.js"></script>
+<script>iFrameResize({}, '#rbb-data--{project-name}')</script>

--- a/package-lock.json
+++ b/package-lock.json
@@ -22801,6 +22801,11 @@
       "resolved": "https://registry.npmjs.org/iferr/-/iferr-0.1.5.tgz",
       "integrity": "sha1-xg7taebY/bazEEofy8ocGS3FtQE="
     },
+    "iframe-resizer": {
+      "version": "4.3.2",
+      "resolved": "https://registry.npmjs.org/iframe-resizer/-/iframe-resizer-4.3.2.tgz",
+      "integrity": "sha512-gOWo2hmdPjMQsQ+zTKbses08mDfDEMh4NneGQNP4qwePYujY1lguqP6gnbeJkf154gojWlBhIltlgnMfYjGHWA=="
+    },
     "ignore": {
       "version": "4.0.6",
       "resolved": "https://registry.npmjs.org/ignore/-/ignore-4.0.6.tgz",

--- a/package.json
+++ b/package.json
@@ -56,6 +56,7 @@
     "d3-scale": "^3.2.3",
     "d3-shape": "^2.0.0",
     "fuse.js": "^3.4.4",
+    "iframe-resizer": "^4.3.2",
     "leaflet": "^1.7.1",
     "leaflet.markercluster": "^1.4.1",
     "lodash": "^4.17.20",

--- a/scripts/setup.sh
+++ b/scripts/setup.sh
@@ -16,6 +16,9 @@ git log --oneline | grep -q 'Start new project with https://github.com/rbb-data/
 # make sure to run from project root
 cd $(dirname $0)/..
 
+# copy resizer script into the public folder
+cp node_modules/iframe-resizer/js/iframeResizer.contentWindow.js public
+
 # substitute '{project-name}' with the current folder name
 sed -i '' 's/{project-name}/'"$(basename $(pwd))"'/g' .env package.json
 

--- a/scripts/setup.sh
+++ b/scripts/setup.sh
@@ -16,11 +16,11 @@ git log --oneline | grep -q 'Start new project with https://github.com/rbb-data/
 # make sure to run from project root
 cd $(dirname $0)/..
 
-# copy resizer script into the public folder
-cp node_modules/iframe-resizer/js/iframeResizer.contentWindow.js public
+# copy resizer scripts to the public folder
+cp node_modules/iframe-resizer/js/iframeResizer{.contentWindow,}.min.js public
 
 # substitute '{project-name}' with the current folder name
-sed -i '' 's/{project-name}/'"$(basename $(pwd))"'/g' .env package.json
+sed -i '' 's/{project-name}/'"$(basename $(pwd))"'/g' .env package.json iframe-embed.html
 
 # clean up the git history
 git commit --amend -m 'Start new project with https://github.com/rbb-data/starter/tree/'$(git rev-parse --short HEAD)

--- a/src/pages/_document.tsx
+++ b/src/pages/_document.tsx
@@ -26,7 +26,7 @@ class MyDocument extends Document {
         >
           <Main />
           <NextScript />
-          <script src='/iframeResizer.contentWindow.js'></script>
+          <script src='/iframeResizer.contentWindow.min.js'></script>
           {process.env.ANALYTICS_ENABLED === 'true' && (
             <>
               <script src='https://www.rbb-online.de/basis/js/jquery-2.2.4.min.js'></script>

--- a/src/pages/_document.tsx
+++ b/src/pages/_document.tsx
@@ -26,6 +26,7 @@ class MyDocument extends Document {
         >
           <Main />
           <NextScript />
+          <script src='/iframeResizer.contentWindow.js'></script>
           {process.env.ANALYTICS_ENABLED === 'true' && (
             <>
               <script src='https://www.rbb-online.de/basis/js/jquery-2.2.4.min.js'></script>


### PR DESCRIPTION
Changes to add [this iframe resizer script](https://github.com/davidjbradshaw/iframe-resizer) by default:

- Add resizer script to dependencies
- Copy required scripts to the public folder (in setup script that is run on `npm install`)
- Load `iframeResizer.contentWindow.js`
- Generate iframe embed code (**Note:** The project name is updated in the setup script but a title has to be set manually)

Closes #39 