### PR TITLE
Improve autocompleting locations using openrouteservice

### DIFF
--- a/src/components/_shared/Search/hooks/useOpenrouteservice.js
+++ b/src/components/_shared/Search/hooks/useOpenrouteservice.js
@@ -1,6 +1,6 @@
 import { useState, useEffect } from 'react';
 import debounce from 'lodash/debounce';
-import { autocomplete, fixBerlinSearchResult } from '../openrouteservice.js';
+import { autocomplete } from '../openrouteservice.js';
 
 export const format = (feature) =>
   `${feature.properties.name}, ${
@@ -27,7 +27,6 @@ const makeRequest = debounce(
     const features = result.features
       // ignore search result that are not in the specified region
       .filter((feature) => feature.properties.region.toLowerCase() === location)
-      .map((feature) => fixBerlinSearchResult(feature))
       // format with lat lng
       .map((feature) => ({
         ...feature,

--- a/src/components/_shared/Search/openrouteservice.js
+++ b/src/components/_shared/Search/openrouteservice.js
@@ -25,87 +25,6 @@ function throwIfError(res) {
     .catch((err) => console.error(err));
 }
 
-// fix taken from https://docs.rbb-online.de/bitbucket/projects/RD/repos/datateam/browse/investitionen/js/l.geosearch.provider.openstreetmap.js
-export function fixBerlinSearchResult(feature) {
-  let borough = feature.properties.borough;
-  let neighbourhood = feature.properties.neighbourhood;
-
-  if (feature.properties.region === 'Berlin') {
-    // TODO temporary fix
-    // check if https://github.com/pelias/pelias/issues/536 is fixed
-    // or use another search API http://wiki.openstreetmap.org/wiki/Search_engines
-    switch (feature.properties.borough) {
-      case 'Tempelhof-Schoneberg':
-        borough = 'Tempelhof-Schöneberg';
-        break;
-      case 'Treptow-Kopenick':
-        borough = 'Treptow-Köpenick';
-        break;
-      case 'Neukolln':
-        borough = 'Neukölln';
-        break;
-      default:
-        break;
-    }
-
-    switch (feature.properties.neighbourhood) {
-      case 'Franzosisch Buchholz':
-        neighbourhood = 'Französisch Buchholz';
-        break;
-      case 'Niederschonhausen':
-        neighbourhood = 'Niederschönhausen';
-        break;
-      case 'Schoneberg':
-        neighbourhood = 'Schöneberg';
-        break;
-      case 'Neukolln':
-        neighbourhood = 'Neukölln';
-        break;
-      case 'Planterwald':
-        neighbourhood = 'Plänterwald';
-        break;
-      case 'Niederschoneweide':
-        neighbourhood = 'Niederschöneweide';
-        break;
-      case 'Oberschoneweide':
-        neighbourhood = 'Oberschöneweide';
-        break;
-      case 'Kopenick':
-        neighbourhood = 'Köpenick';
-        break;
-      case 'Grunau':
-        neighbourhood = 'Grünau';
-        break;
-      case 'Muggelheim':
-        neighbourhood = 'Müggelheim';
-        break;
-      case 'Schmockwitz':
-        neighbourhood = 'Schmöckwitz';
-        break;
-      case 'Lubars':
-        neighbourhood = 'Lübars';
-        break;
-      case 'Markisches Viertel':
-        neighbourhood = 'Märkisches Viertel';
-        break;
-      case 'Neu-Hohenschonhausen':
-        neighbourhood = 'Neu-Hohenschönhausen';
-        break;
-      default:
-        break;
-    }
-  }
-
-  return {
-    ...feature,
-    properties: {
-      ...feature.properties,
-      borough: borough,
-      neighbourhood: neighbourhood,
-    },
-  };
-}
-
 /**
  * Fetches autocomplete suggestions for a string of text.
  *
@@ -147,6 +66,7 @@ export function autocomplete({
     'focus.point.lon': 13.3827185,
     ...bounds,
     'boundary.country': 'DEU',
+    lang: 'de',
   };
 
   const uri = `//api.openrouteservice.org/geocode/autocomplete?${toUriString(


### PR DESCRIPTION
Two issues are addressed:

- To restrict a query to a specific region, `', Berlin'` or `', Brandenburg'` is added to the query string. This can lead to weird behaviour. For example, no results are returned for queries that contain less than five or six (bur more than one) character. To prevent this, we pass the query as given by the user but filter the results afterwards for locations in the specified region. Obviously, this is risky (we could filter everything) but I believe this is unlikely as bounding box and focus point are specified.

- https://github.com/pelias/pelias/issues/536 is fixed, so we can get rid of the temporary fix